### PR TITLE
Revision 0.113

### DIFF
--- a/BZI/symmetry.py
+++ b/BZI/symmetry.py
@@ -2275,6 +2275,7 @@ def brillouin_zone_mapper(grid, rlattice_vectors, grid_vectors, shift, eps=15):
     for i, pt1 in enumerate(reduced_grid_copy):
         pt1 = bring_into_cell(pt1, mink_basis)
         norm_pt1 = np.dot(pt1, pt1)
+        reduced_grid[i] = pt1
         for n in product([-1,0], repeat=3):
             pt2 = pt1 + np.dot(mink_basis, n)
             norm_pt2 = np.dot(pt2, pt2)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # Revision History
 
+## Revision 0.113
+- Fixed 'brillouin_zone_mapper' in symmetry.py. The reduced_grid
+  contained points outside of the Minkowski unit cell, so, in cases
+  where the original pt1 was the shortest point, the translationally
+  equivalent point in reduced_grid was never replaced.
+
 ## Revision 0.1.12
 - Fixed `brillouin_zone_mapper`. The k-points are symmetry reduced,
   mapped into the first unit cell in the Minkowski basis, then looks


### PR DESCRIPTION
Fixed 'brillouin_zone_mapper' in symmetry.py. The reduced_grid contained points outside of the Minkowski unit cell, so, in cases where the original pt1 was the shortest point, the translationally equivalent point in reduced_grid was never replaced.